### PR TITLE
滝の摩擦をなくす

### DIFF
--- a/Assets/Scenes/Takumi 2.unity
+++ b/Assets/Scenes/Takumi 2.unity
@@ -2346,7 +2346,7 @@ CapsuleCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 155592373}
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 13400000, guid: 48879c935bc8d490782ca88b7ee4dad9, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -30607,7 +30607,7 @@ MeshCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1026238269}
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 13400000, guid: 48879c935bc8d490782ca88b7ee4dad9, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0

--- a/Assets/otherAsset/Nicrom/Shaders/Wind/UpgradePackages/LPW_HDRP_Unity2021.3+.unitypackage.meta
+++ b/Assets/otherAsset/Nicrom/Shaders/Wind/UpgradePackages/LPW_HDRP_Unity2021.3+.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0077ec58043001e4f8eb8017d34dc3dc
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/otherAsset/Nicrom/Shaders/Wind/UpgradePackages/LPW_HDRP_Unity2022.2+.unitypackage.meta
+++ b/Assets/otherAsset/Nicrom/Shaders/Wind/UpgradePackages/LPW_HDRP_Unity2022.2+.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f33a3944d7082ee42b5a51ae9c09e7a2
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/otherAsset/Nicrom/Shaders/Wind/UpgradePackages/LPW_URP_Unity2020.3+.unitypackage.meta
+++ b/Assets/otherAsset/Nicrom/Shaders/Wind/UpgradePackages/LPW_URP_Unity2020.3+.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 01750cb69131c16468bcc2d105f9cd1b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
ステージ3の滝の摩擦の削除

## 変更点
滝に向かってunityちゃんが移動していると摩擦によってunityちゃんが引っかかるため
unityちゃんの摩擦を0に設定
滝の摩擦を0に設定
## 影響範囲
Takumi2.unity内のunityちゃんオブジェクトと滝オブジェクト